### PR TITLE
guard jemalloc behind the 'jemalloc' feature to simplify compilation with the default profile

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -46,7 +46,7 @@ jobs:
 
         - name: "Build ${{ matrix.target }}"
           run: |
-            cargo build --release --locked --target ${{ matrix.target }} --features self-update
+            cargo build --release --locked --target ${{ matrix.target }} --features dist
 
         - name: "Test binary"
           if: ${{ matrix.target == 'aarch64-apple-darwin' }}
@@ -92,7 +92,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build ${{ matrix.target }}
-        run: cargo build --release --locked --target ${{ matrix.target }} --features self-update
+        run: cargo build --release --locked --target ${{ matrix.target }} --features dist
 
       - name: "Archive ${{ matrix.target }}"
         shell: bash
@@ -134,7 +134,7 @@ jobs:
           fi
       - name: "Build binary"
         run: |
-          cargo zigbuild --release --locked --target ${{ matrix.platform.target }}.2.17 --features self-update
+          cargo zigbuild --release --locked --target ${{ matrix.platform.target }}.2.17 --features dist
         env:
           CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER: s390x-linux-gnu-gcc
       - uses: uraimo/run-on-arch-action@aa8e672a03e10b403401927ea2ceda57e1b68ac3 # v3
@@ -184,7 +184,7 @@ jobs:
           rustup target add ${{ matrix.platform.target }}
       - name: "Build binary"
         run: |
-          cargo build --release --locked --target ${{ matrix.platform.target }} --features self-update
+          cargo build --release --locked --target ${{ matrix.platform.target }} --features dist
         env:
           CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER: powerpc64le-linux-gnu-gcc
           CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER: powerpc64-linux-gnu-gcc
@@ -232,7 +232,7 @@ jobs:
             pip3 install cargo-zigbuild
           fi
       - name: "Build binary"
-        run: cargo zigbuild --release --locked --target ${{ matrix.platform.target }} --features self-update
+        run: cargo zigbuild --release --locked --target ${{ matrix.platform.target }} --features dist
       - uses: uraimo/run-on-arch-action@aa8e672a03e10b403401927ea2ceda57e1b68ac3 # v3
         name: "Test binary"
         with:
@@ -283,7 +283,7 @@ jobs:
             pip3 install cargo-zigbuild
           fi
       - name: "Build binary"
-        run: cargo zigbuild --release --locked --target ${{ matrix.target }} --features self-update
+        run: cargo zigbuild --release --locked --target ${{ matrix.target }} --features dist
 
       - name: "Test binary"
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -331,7 +331,7 @@ jobs:
           rustup target add ${{ matrix.platform.target }}
       - name: "Build binary"
         run: |
-          cargo build --release --locked --target ${{ matrix.platform.target }} --features self-update
+          cargo build --release --locked --target ${{ matrix.platform.target }} --features dist
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
           CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Significantly reduce binary size by scrutinizing dependencies
+- To simplify installation from source with the default profile, `jemalloc` is feature-gated. While it's included in prebuilt binaries, users installing from source must explicitly enable the `jemalloc` feature to use it instead of the system allocator, i.e.: `cargo install --git https://github.com/CramBL/mdns-scanner mdns-scanner --features jemalloc`
 
 ## [0.12.1] - 2025-06-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ axoupdater = { workspace = true, features = [
 mimalloc = "0.1.47"
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
-tikv-jemallocator = "0.6.0"
+tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
@@ -49,6 +49,9 @@ inherits = "release"
 
 [features]
 default = []
+# Toggle for the features that are enabled for the distributed prebuilt version
+dist = ["jemalloc", "self-update"]
+jemalloc = ["tikv-jemallocator"]
 # Adds self-update functionality. This feature is only enabled for the cargo-dist installer
 # and should be left unselected when building mdns-scanner for package managers.
 self-update = ["axoupdater", "mds-cli/self-update"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,7 +20,7 @@ install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
 # Whether to install an updater program
 install-updater = false
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Build only the required packages, and individually
 precise-builds = true
 # Whether CI should include auto-generated code to build local artifacts

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(all(
+    feature = "jemalloc",
     not(target_os = "windows"),
     not(target_os = "openbsd"),
     not(target_os = "freebsd"),


### PR DESCRIPTION
Should resolve #68 