### PR TITLE
Remove `jemalloc` from the prebuilt binaries for all platforms except…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+## [0.16.1] - 2025-06-29
+
+### Changed
+
+- Remove `jemalloc` from the prebuilt binaries for all platforms except for x86_64 Linx and MacOS. Please report any issues, `jemalloc` will be completely removed if more issues pop up.
+
 ## [0.16.0] - 2025-06-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mdns-scanner"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mds-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "clap",
  "mds-default",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mds-config"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "config",
  "dirs",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mds-default"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "paste",
  "pretty_assertions",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "mds-tui"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "color-eyre",
  "mds-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ axoupdater = { workspace = true, features = [
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.47"
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
@@ -71,7 +71,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Marc Beck König <mgit@tuta.io>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
     not(target_os = "windows"),
     not(target_os = "openbsd"),
     not(target_os = "freebsd"),
-    any(
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "powerpc64"
-    )
+    target_arch = "x86_64"
 ))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
… for x86_64 Linx and MacOS

resolves #85 