### PR TITLE
On high-end CPUs on unix platforms, the "Maximum number of open files…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+## [0.17.1] - 2025-06-30
+
+### Changed
+
+- On high-end CPUs on unix platforms, the "Maximum number of open files" would likely be hit, `mdns-scanner` now dynamically requests to raise that limit, or limits socket I/O if needed.
+
 ## [0.17.0] - 2025-06-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mdns-scanner"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mds-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "clap",
  "mds-default",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mds-config"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "config",
  "dirs",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mds-default"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "paste",
  "pretty_assertions",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "mds-tui"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "color-eyre",
  "mds-cli",
@@ -1670,6 +1670,7 @@ dependencies = [
  "mds-log",
  "pnet",
  "reqwest",
+ "rlimit",
  "zip",
 ]
 
@@ -2288,6 +2289,15 @@ name = "ringbuffer"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Marc Beck König <mgit@tuta.io>"]
@@ -111,6 +111,7 @@ unicode-width = "0.2.0"
 threadpool = "1.8.1"
 dns-lookup = "2.0.4"
 config = { version = "0.15.11", features = ["toml"], default-features = false }
+rlimit = "0.10.2"
 
 # Dev-dependencies
 testresult = "0.4.1"

--- a/crates/mds-util/Cargo.toml
+++ b/crates/mds-util/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 [dependencies]
 mds-log.workspace = true
 mds-config.workspace = true
+rlimit.workspace = true
 pnet = "0.35.0"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/mds-util/src/resource_scaling.rs
+++ b/crates/mds-util/src/resource_scaling.rs
@@ -11,36 +11,53 @@ const MIN_PARALLELISM: usize = 1;
 const MIN_LOW_TIER_THREADS: usize = 32;
 const MAX_IO_THREADS: usize = 8192;
 
+// Default NOFILE on linux
+const DEFAULT_MAX_FD: u64 = 1024;
+
 enum PerformanceTier {
-    High,
-    Mid,
-    Low,
+    High(usize),
+    Mid(usize),
+    Low(usize),
 }
 
 impl PerformanceTier {
     pub fn from(available_parallelism: usize) -> Self {
         if available_parallelism >= 32 {
-            PerformanceTier::High
+            PerformanceTier::High(available_parallelism)
         } else if available_parallelism >= 8 {
-            PerformanceTier::Mid
+            PerformanceTier::Mid(available_parallelism)
         } else {
-            PerformanceTier::Low
+            PerformanceTier::Low(available_parallelism)
         }
     }
 
     pub fn thread_scale(&self) -> usize {
         match self {
-            PerformanceTier::High | PerformanceTier::Mid => 32,
-            PerformanceTier::Low => 16,
+            PerformanceTier::High(_) | PerformanceTier::Mid(_) => 32,
+            PerformanceTier::Low(_) => 16,
         }
     }
 
     pub fn passive_refresh_interval(&self) -> Duration {
         match self {
-            PerformanceTier::High => Duration::from_millis(50),
-            PerformanceTier::Mid => Duration::from_millis(100),
-            PerformanceTier::Low => Duration::from_millis(300),
+            PerformanceTier::High(_) => Duration::from_millis(50),
+            PerformanceTier::Mid(_) => Duration::from_millis(100),
+            PerformanceTier::Low(_) => Duration::from_millis(300),
         }
+    }
+
+    pub fn max_threads(&self) -> usize {
+        match self {
+            PerformanceTier::High(parallelism)
+            | PerformanceTier::Mid(parallelism)
+            | PerformanceTier::Low(parallelism) => self.thread_scale() * parallelism,
+        }
+    }
+
+    pub fn max_file_descriptors(&self) -> u64 {
+        // 2 for each scanner thread, one TCP socket and one ICMP/raw socket
+        // we choose 3 for the extras for sleeping sockets, host up checking, DNS-SD discovery and misc.
+        (self.max_threads() * 3) as u64
     }
 }
 
@@ -53,6 +70,7 @@ fn get_available_parallelism() -> usize {
 
 #[derive(Clone, Copy)]
 pub struct HostResources {
+    fd_limit: u64,
     parallelism: usize,
     last_check: Instant,
 }
@@ -66,15 +84,30 @@ impl Default for HostResources {
 impl HostResources {
     pub fn new() -> Self {
         let parallelism = get_available_parallelism();
+        let perf_tier = PerformanceTier::from(parallelism);
+        let max_fd = perf_tier.max_file_descriptors();
+        let fd_limit = rlimit::increase_nofile_limit(max_fd).unwrap_or(DEFAULT_MAX_FD);
+
         Self {
+            fd_limit,
             parallelism,
             last_check: Instant::now(),
         }
     }
 
+    pub fn max_file_descriptors(&mut self) -> u64 {
+        let curr_max_fd = self.performance_tier().max_file_descriptors();
+        if self.fd_limit < curr_max_fd {
+            self.fd_limit = rlimit::increase_nofile_limit(curr_max_fd).unwrap_or(DEFAULT_MAX_FD);
+        }
+        curr_max_fd
+    }
+
     pub fn max_threads(&mut self) -> usize {
-        let calculated_threads = self.performance_tier().thread_scale() * self.parallelism;
-        calculated_threads.clamp(MIN_LOW_TIER_THREADS, MAX_IO_THREADS)
+        let calculated_threads = self.performance_tier().max_threads();
+        let max_threads = calculated_threads.clamp(MIN_LOW_TIER_THREADS, MAX_IO_THREADS);
+        let scaled_max_fd = (self.max_file_descriptors() / 3) as usize;
+        max_threads.min(scaled_max_fd)
     }
 
     pub fn passive_refresh_interval(&mut self) -> Duration {
@@ -91,5 +124,35 @@ impl HostResources {
     fn performance_tier(&mut self) -> PerformanceTier {
         self.maybe_refresh();
         PerformanceTier::from(self.parallelism)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_full_resource_management_workflow() {
+        let mut resources = HostResources::new();
+
+        println!(
+            "System detected {} CPU cores(-esque)",
+            resources.parallelism
+        );
+
+        let max_threads = resources.max_threads();
+        let max_fds = resources.max_file_descriptors();
+        let refresh_interval = resources.passive_refresh_interval();
+
+        println!(
+            "Configured for {max_threads} threads, {max_fds} FDs, {}ms refresh",
+            refresh_interval.as_millis()
+        );
+
+        // Verify the configuration makes sense
+        assert!(max_threads > 0);
+        assert!(max_fds >= max_threads as u64 * 3); // At least 3 FDs per thread
+        assert!(refresh_interval.as_millis() >= 50);
+        assert!(refresh_interval.as_millis() <= 300);
     }
 }


### PR DESCRIPTION
…" would likely be hit, `mdns-scanner` now dynamically requests to raise that limit, or limits socket I/O if needed.