### PR TITLE
Wrap lines when displaying properties of a DNS-SD service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 
+- Wrap lines when displaying properties of a DNS-SD service
 - Differentiate timeout errors (logged as `debug`) from other errors when performing mDNS lookup
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ name = "mds-ipinfo"
 version = "0.1.0"
 dependencies = [
  "mds-util",
+ "pretty_assertions",
  "unicode-width 0.2.0",
 ]
 

--- a/crates/mds-ipinfo/Cargo.toml
+++ b/crates/mds-ipinfo/Cargo.toml
@@ -13,5 +13,8 @@ rust-version.workspace = true
 mds-util.workspace = true
 unicode-width.workspace = true
 
+[dev-dependencies]
+pretty_assertions.workspace = true
+
 [lints]
 workspace = true

--- a/crates/mds-ipinfo/src/service.rs
+++ b/crates/mds-ipinfo/src/service.rs
@@ -41,11 +41,145 @@ impl fmt::Display for ServiceInstance {
             .map(|h| format!(" @ {h}"))
             .unwrap_or_default();
         let port = self.port;
-        let txt = self
-            .txt
-            .as_deref()
-            .map(|t| t.join(", "))
-            .unwrap_or_default();
-        write!(f, "{name}{host_opt}:{port}\n{txt}")
+
+        write!(f, "{name}{host_opt}:{port}")?;
+
+        if let Some(txt_records) = &self.txt {
+            const MAX_LINE_LENGTH: usize = 65;
+            let mut current_line = String::new();
+
+            for (i, record) in txt_records.iter().enumerate() {
+                let prefix = if i == 0 { "\n" } else { ", " };
+                let new_content = format!("{prefix}{record}");
+
+                if !current_line.is_empty()
+                    && current_line.len() + new_content.len() > MAX_LINE_LENGTH
+                {
+                    writeln!(f, "{current_line}")?;
+                    current_line = record.to_string();
+                } else {
+                    current_line.push_str(&new_content);
+                }
+            }
+
+            write!(f, "{current_line}")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_str_eq;
+
+    #[test]
+    fn displays_name_and_port() {
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            None,
+        );
+        assert_str_eq!(service.to_string(), "test:8080");
+    }
+
+    #[test]
+    fn displays_hostname_when_present() {
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            Some("host.local".to_string()),
+            8080,
+            None,
+        );
+        assert_str_eq!(service.to_string(), "test @ host.local:8080");
+    }
+
+    #[test]
+    fn displays_single_txt_record() {
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            Some(vec!["key=value".to_string()]),
+        );
+        assert_str_eq!(service.to_string(), "test:8080\nkey=value");
+    }
+
+    #[test]
+    fn displays_multiple_txt_records_on_same_line() {
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            Some(vec!["a=1".to_string(), "b=2".to_string()]),
+        );
+        assert_str_eq!(service.to_string(), "test:8080\na=1, b=2");
+    }
+
+    #[test]
+    fn wraps_long_txt_records() {
+        let long_record = "x".repeat(55);
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            Some(vec![
+                "short".to_string(),
+                long_record.clone(),
+                long_record.clone(),
+            ]),
+        );
+        let expected = format!("test:8080\nshort, {long_record}\n{long_record}");
+        assert_str_eq!(service.to_string(), expected);
+    }
+
+    #[test]
+    fn handles_txt_record_exactly_at_line_limit() {
+        let record = "x".repeat(65);
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            Some(vec![record.clone()]),
+        );
+        assert_str_eq!(service.to_string(), format!("test:8080\n{record}"));
+    }
+
+    #[test]
+    fn wraps_when_adding_comma_exceeds_limit() {
+        let record1 = "x".repeat(63);
+        let record2 = "y".to_string();
+        let service = ServiceInstance::new(
+            "test".to_string(),
+            "_http._tcp".to_string(),
+            None,
+            8080,
+            Some(vec![record1.clone(), record2.clone()]),
+        );
+        let expected = format!("test:8080\n{record1}\n{record2}");
+        assert_str_eq!(service.to_string(), expected);
+    }
+
+    #[test]
+    fn combines_all_elements() {
+        let service = ServiceInstance::new(
+            "web".to_string(),
+            "_http._tcp".to_string(),
+            Some("server.local".to_string()),
+            443,
+            Some(vec!["ssl=true".to_string(), "version=2.0".to_string()]),
+        );
+        assert_str_eq!(
+            service.to_string(),
+            "web @ server.local:443\nssl=true, version=2.0"
+        );
     }
 }


### PR DESCRIPTION
Resolves #https://github.com/CramBL/mdns-scanner/issues/33 in better way than adding horizontal scroll