### PR TITLE
log and discard TXT records with key/value pairs that are invalid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Fixed
+
+- [#147](https://github.com/CramBL/mdns-scanner/issues/147) Log and discard key/value pairs in TXT records with invalid UTF-8 instead of displaying the lossy representation (where invalid characters are replaced by �)
+
 ### Changed
 
 - Failing to resolve a DNS-SD service IP within the 2s timeout is no longer treated as an error

--- a/crates/mds-dns-sd/src/discover.rs
+++ b/crates/mds-dns-sd/src/discover.rs
@@ -128,13 +128,20 @@ fn handle_dns_record(
             test_expect!(query::query_a_and_aaaa(srv.target(), socket));
         }
         RData::TXT(txt) => {
-            let parsed_txt = txt
-                .txt_data()
-                .iter()
-                .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
-                .collect::<Vec<_>>();
-            log::debug!("TXT: {hostname} -> {parsed_txt:?}");
-            registry.set_txt(&hostname, parsed_txt);
+            let mut txt_pairs = Vec::with_capacity(txt.txt_data().len());
+            for data in txt.txt_data() {
+                match str::from_utf8(data) {
+                    Ok(t) => txt_pairs.push(t.to_owned()),
+                    Err(e) => {
+                        log::warn!(
+                            "Ignoring TXT key/value for service '{hostname}': {e}. Lossy representation: '{}'",
+                            String::from_utf8_lossy(data)
+                        )
+                    }
+                }
+            }
+            log::debug!("TXT: {hostname} -> {txt_pairs:?}");
+            registry.set_txt(&hostname, txt_pairs);
         }
         RData::CNAME(cname) => {
             let canonical = util::unescape_dns_name_to_string(cname);


### PR DESCRIPTION
Resolves #147 