### PR TITLE
fix table filter scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+### Changed
+
+- Selecting next/previous table row no longer wraps
+
+### Fixed
+
 - Fix [#186](https://github.com/CramBL/mdns-scanner/issues/186): table stayed scrolled down when a search term was applied that filtered out items in view, but scrolling up a bit would fill the view with items again.
 
 ## [0.24.1] - 2025-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [unreleased]
 
+## [0.24.2] - 2025-11-01
+
 ### Changed
 
 - Selecting next/previous table row no longer wraps
 
 ### Fixed
 
+- Fix `RTT` stats periodically getting overwritten
 - Fix [#186](https://github.com/CramBL/mdns-scanner/issues/186): table stayed scrolled down when a search term was applied that filtered out items in view, but scrolling up a bit would fill the view with items again.
 
 ## [0.24.1] - 2025-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Fix [#186](https://github.com/CramBL/mdns-scanner/issues/186): table stayed scrolled down when a search term was applied that filtered out items in view, but scrolling up a bit would fill the view with items again.
+
 ## [0.24.1] - 2025-10-31
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "mdns-scanner"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "axoupdater",
  "color-eyre",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mds-cli"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "clap",
  "mds-default",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mds-config"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "config",
  "dirs",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "mds-default"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "pastey",
  "pretty_assertions",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "mds-tui"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "arboard",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.package]
 description = "Scan a network and create a list of IPs and associated hostnames, including DNS-SD service instances, mDNS hostnames and other aliases."
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Marc Beck König <mgit@tuta.io>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ mimalloc = "0.1.47"
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", optional = true }
 
+[dev-dependencies]
+insta = "1.43.1"
+
 [profile.release]
 opt-level = 3
 debug = false
@@ -204,6 +207,3 @@ needless_pass_by_value = "warn"
 needless_range_loop = "warn"
 negative_feature_names = "warn"
 non_zero_suggestions = "warn"
-
-[dev-dependencies]
-insta = "1.43.1"

--- a/crates/mds-collector/src/lib.rs
+++ b/crates/mds-collector/src/lib.rs
@@ -43,7 +43,7 @@ pub fn spawn_collector(
         .expect("Failed spawning Ip info collector thread");
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CollectorUpdate {
     IpInfo(IpInfo),
     PacketSeen {

--- a/crates/mds-ipinfo/src/db.rs
+++ b/crates/mds-ipinfo/src/db.rs
@@ -31,8 +31,9 @@ impl IpDb {
 
         // Remove and merge the matching entries
         for i in matching_indices.iter().rev() {
-            let old_info = self.ip_info.swap_remove(*i);
-            merged_info.merge(old_info);
+            let mut old_info = self.ip_info.swap_remove(*i);
+            old_info.merge(merged_info);
+            merged_info = old_info;
         }
 
         merged_info.set_last_updated_now();

--- a/crates/mds-ipinfo/src/lib.rs
+++ b/crates/mds-ipinfo/src/lib.rs
@@ -7,11 +7,12 @@ use std::{
 use mds_util::host_up::{HostUpInfo, ReachedBy};
 use unicode_width::UnicodeWidthStr;
 
-use crate::service::ServiceInstance;
+use crate::{rtt_stats::RttStats, service::ServiceInstance};
 
 pub mod db;
 pub use ip::IpForHost;
 pub mod ip;
+pub mod rtt_stats;
 pub mod service;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -26,43 +27,6 @@ impl fmt::Display for LastKnownStatus {
             LastKnownStatus::Online => write!(f, "Online"),
             LastKnownStatus::Offline => write!(f, "Offline"),
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RttStats {
-    pub first: Duration,
-    pub latest: Duration,
-    pub avg: Duration,
-    pub min: Duration,
-    pub max: Duration,
-    count: u64,
-}
-
-impl RttStats {
-    pub(crate) fn new(first: Duration) -> Self {
-        Self {
-            first,
-            latest: first,
-            avg: first,
-            min: first,
-            max: first,
-            count: 1,
-        }
-    }
-
-    pub(crate) fn update(&mut self, new_rtt: Duration) {
-        self.count += 1;
-        self.latest = new_rtt;
-
-        let avg_secs = self.avg.as_secs_f32();
-        let new_secs = new_rtt.as_secs_f32();
-
-        let updated_avg_secs = avg_secs + (new_secs - avg_secs) / self.count as f32;
-
-        self.avg = Duration::from_secs_f32(updated_avg_secs);
-        self.min = new_rtt.min(self.min);
-        self.max = new_rtt.max(self.max);
     }
 }
 
@@ -81,16 +45,29 @@ pub struct IpInfo {
 
 impl IpInfo {
     /// Merges another `IpInfo` into this one.
+    ///
+    /// Prioritizes `self` over `other` for fields with no meaningful merge strategy
     pub fn merge(&mut self, other: Self) {
-        self.ip = self.ip.merge(other.ip);
+        let Self {
+            ip,
+            reached_by,
+            rtt,
+            names,
+            service_instances,
+            last_known_status,
+            seen_count,
+            last_updated,
+        } = other;
 
-        self.seen_count += other.seen_count;
+        self.ip = self.ip.merge(ip);
 
-        self.names.extend(other.names);
+        self.seen_count += seen_count;
+
+        self.names.extend(names);
         self.names.sort_unstable();
         self.names.dedup();
 
-        if let Some(other_services) = other.service_instances {
+        if let Some(other_services) = service_instances {
             for service in other_services {
                 self.update_with_service_instance(service);
             }
@@ -100,7 +77,7 @@ impl IpInfo {
 
         // Merge the 'reached_by' status, preferring more reliable discovery methods.
         // EchoReply (ping) > Port (TCP) > Other.
-        if let Some(other_reached_by) = other.reached_by {
+        if let Some(other_reached_by) = reached_by {
             match self.reached_by {
                 Some(ReachedBy::EchoReply) => {}
                 Some(ReachedBy::Port(_)) => {
@@ -114,13 +91,17 @@ impl IpInfo {
             }
         }
 
-        if self.rtt.is_none() {
-            self.rtt = other.rtt;
+        if let Some(cur_rtt) = &mut self.rtt {
+            if let Some(other_rtt) = rtt {
+                cur_rtt.merge(other_rtt);
+            }
+        } else {
+            self.rtt = rtt;
         }
 
-        if other.last_updated > self.last_updated {
-            self.last_updated = other.last_updated;
-            self.last_known_status = other.last_known_status;
+        if self.last_updated < last_updated {
+            self.last_updated = last_updated;
+            self.last_known_status = last_known_status;
         }
     }
 
@@ -146,7 +127,7 @@ impl IpInfo {
         }
     }
 
-    pub fn info(mut self, info: HostUpInfo) -> Self {
+    pub fn with_info(mut self, info: HostUpInfo) -> Self {
         self.reached_by = Some(info.reached_by);
         self.rtt = Some(RttStats::new(info.rtt));
         self
@@ -294,15 +275,13 @@ impl IpInfo {
     ) {
         self.last_known_status = status;
         self.set_last_updated_now();
-        if let Some(rtt) = &mut self.rtt {
-            if let Some(new_rtt) = new_rtt {
-                rtt.update(new_rtt);
-            }
-        } else {
-            // This is the case if a DNS-SD service was found at this IP before it was discovered
-            // via the network scanner
-            if let Some(new_rtt) = new_rtt {
-                self.rtt = Some(RttStats::new(new_rtt));
+        if let Some(new_rtt) = new_rtt {
+            if let Some(cur_rtt) = &mut self.rtt {
+                cur_rtt.update(new_rtt);
+            } else {
+                // This is the case if a DNS-SD service was found at this IP before it was discovered
+                // via the network scanner
+                self.rtt = Some(RttStats::new(new_rtt))
             }
         }
     }

--- a/crates/mds-ipinfo/src/rtt_stats.rs
+++ b/crates/mds-ipinfo/src/rtt_stats.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RttStats {
+    first: Duration,
+    latest: Duration,
+    pub avg: Duration,
+    pub min: Duration,
+    pub max: Duration,
+    count: u64,
+}
+
+impl RttStats {
+    pub(crate) fn new(first: Duration) -> Self {
+        Self {
+            first,
+            latest: first,
+            avg: first,
+            min: first,
+            max: first,
+            count: 1,
+        }
+    }
+
+    #[inline]
+    pub fn on_discover(&self) -> Duration {
+        self.first
+    }
+
+    #[inline]
+    pub fn latest(&self) -> Duration {
+        self.latest
+    }
+
+    pub(crate) fn update(&mut self, new_rtt: Duration) {
+        self.count += 1;
+        self.latest = new_rtt;
+
+        let avg_secs = self.avg.as_secs_f32();
+        let new_secs = new_rtt.as_secs_f32();
+
+        let updated_avg_secs = avg_secs + (new_secs - avg_secs) / self.count as f32;
+
+        self.avg = Duration::from_secs_f32(updated_avg_secs);
+        self.min = new_rtt.min(self.min);
+        self.max = new_rtt.max(self.max);
+    }
+
+    /// Merges another `RttStats` into this one.
+    ///
+    /// Works with the assumption that `self` is an "older" instance
+    /// and rioritizes `self` over `other` for fields with no meaningful merge strategy
+    pub(crate) fn merge(&mut self, other: Self) {
+        let Self {
+            first: _,
+            latest,
+            avg,
+            min,
+            max,
+            count,
+        } = other;
+
+        // since `self` is oldest, we overwrite with latest from `other`
+        self.latest = latest;
+        self.min = self.min.min(min);
+        self.max = self.max.max(max);
+
+        let total_count = self.count + count;
+        let self_total_secs = self.avg.as_secs_f32() * self.count as f32;
+        let other_total_secs = avg.as_secs_f32() * count as f32;
+        let combined_total_secs = self_total_secs + other_total_secs;
+        let updated_avg_secs = combined_total_secs / total_count as f32;
+        self.avg = Duration::from_secs_f32(updated_avg_secs);
+        self.count = total_count;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtt_stats_merge_correctly_calculates_weighted_average() {
+        const EPSILON: Duration = Duration::from_nanos(10);
+
+        // Stats A: 2 samples, Avg = 10ms (Total RTT sum = 20ms)
+        let rtt_a_initial = Duration::from_millis(10);
+        let mut stats_a = RttStats::new(rtt_a_initial);
+        stats_a.update(rtt_a_initial);
+
+        // Stats B: 1 sample, Avg = 100ms (Total RTT sum = 100ms)
+        let stats_b = RttStats::new(Duration::from_millis(100));
+        stats_a.merge(stats_b);
+
+        let expected_avg = Duration::from_millis(40);
+
+        let diff = stats_a.avg.abs_diff(expected_avg);
+
+        assert!(
+            diff < EPSILON,
+            "Averages diverged by {diff:?}. Calculated: {:?}, Expected: {expected_avg:?}",
+            stats_a.avg,
+        );
+
+        assert_eq!(stats_a.count, 3);
+        assert_eq!(stats_a.min, Duration::from_millis(10));
+        assert_eq!(stats_a.max, Duration::from_millis(100));
+    }
+}

--- a/crates/mds-netscan/src/scan.rs
+++ b/crates/mds-netscan/src/scan.rs
@@ -53,7 +53,7 @@ pub(crate) fn scan_ip_range(
             let tcp_ports = ports.to_vec();
             move || {
                 if let Some(host_up_info) = check_host_up(ip, &tcp_ports, timeout_settings) {
-                    let mut ip_info = IpInfo::from_ip(IpAddr::V4(ip)).info(host_up_info);
+                    let mut ip_info = IpInfo::from_ip(IpAddr::V4(ip)).with_info(host_up_info);
 
                     if let Some(hostnames) = dns_reverse_lookup(local_ip, ip) {
                         ip_info.set_names(hostnames);

--- a/crates/mds-tui/src/table_pane.rs
+++ b/crates/mds-tui/src/table_pane.rs
@@ -132,10 +132,11 @@ impl TablePane {
     }
 
     pub fn next_row(&mut self) {
+        let last_row_idx = self.ip_db.len() - 1;
         let i = match self.state.selected() {
             Some(i) => {
-                if i >= self.ip_db.len() - 1 {
-                    0
+                if i >= last_row_idx {
+                    last_row_idx
                 } else {
                     i + 1
                 }
@@ -150,7 +151,7 @@ impl TablePane {
         let i = match self.state.selected() {
             Some(i) => {
                 if i == 0 {
-                    self.ip_db.len() - 1
+                    0
                 } else {
                     i - 1
                 }

--- a/crates/mds-tui/src/table_pane.rs
+++ b/crates/mds-tui/src/table_pane.rs
@@ -95,7 +95,7 @@ impl TablePane {
 
     pub(crate) fn recv_new_ip_info(&mut self) {
         while let Ok(update) = self.rx_ip_info.try_recv() {
-            if self.refreshing && !matches!(update, CollectorUpdate::Refresh) {
+            if self.refreshing && update != CollectorUpdate::Refresh {
                 continue; // ignore stale updates during a refresh
             }
             match update {
@@ -223,6 +223,19 @@ impl TablePane {
         in_focus: bool,
     ) {
         let ip_info = Self::filtered_ip_info(&self.ip_db, &self.cfg, search_pattern);
+
+        let ip_info_filtered_len = ip_info.len();
+        // Check if the current selected index is out of bounds for the filtered list.
+        // Reset the selection and and reset the scrollbar state as well, so it appears scrolled to the top
+        if self
+            .state
+            .selected()
+            .is_some_and(|i| i >= ip_info_filtered_len)
+        {
+            self.state.select(None);
+            self.scroll_state = self.scroll_state.position(0);
+        }
+
         self.longest_item_lens = util::ColumnConstraints::new(&ip_info);
 
         let header = Self::header(self.header_style());
@@ -243,12 +256,13 @@ impl TablePane {
         };
 
         let table_block = Block::bordered()
-            .title(self.pane_title(ip_info.len() as u16))
+            .title(self.pane_title(ip_info_filtered_len as u16))
             .border_set(block_border);
         let table: Table<'_> = table.block(table_block);
 
         frame.render_stateful_widget(table, area, &mut self.state);
-        self.render_scrollbar(frame, area, ip_info.len());
+        self.render_scrollbar(frame, area, ip_info_filtered_len);
+
         let selected_idx = self.state.selected().unwrap_or(0);
         let selected_ip_info = ip_info.get(selected_idx).copied();
         self.ip_info_popup.render(frame, selected_ip_info);

--- a/crates/mds-tui/src/table_pane/ipinfo_popup.rs
+++ b/crates/mds-tui/src/table_pane/ipinfo_popup.rs
@@ -49,10 +49,10 @@ impl IpInfoPopUp {
         msg_lines.push(Line::from(vec![description, val, Span::raw(" ago")]));
 
         if let Some(rtt_stats) = info.rtt {
-            let first = rtt_stats.first;
-            let latest = rtt_stats.latest;
+            let on_discover = rtt_stats.on_discover();
+            let latest = rtt_stats.latest();
             let description = Span::raw("RTT on discover/latest: ");
-            let val_first = Span::styled(format!("{first:.1?} "), Style::new().yellow());
+            let val_first = Span::styled(format!("{on_discover:.1?} "), Style::new().yellow());
             let val_latest = Span::styled(format!("{latest:.1?}"), Style::new().white());
             msg_lines.push(Line::from(vec![description, val_first, val_latest]));
 


### PR DESCRIPTION
Resolves #186 

- **Fix [#186](https://github.com/CramBL/mdns-scanner/issues/186): table stayed scrolled down when a search term was applied that filtered out items in view, but scrolling up a bit would fill the view with items again.**
- **don't wrap selected table row on next/prev**
- **Fix `RTT` stats periodically getting overwritten**
