### PR TITLE
Remove GitHub Actions updates from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    groups:
-      GitHub_Actions:
-        patterns:
-          - "*" # open a single pull request to update all actions
-    schedule:
-      interval: weekly
   - package-ecosystem: cargo
     directory: "/"
     groups:


### PR DESCRIPTION
it's just annoying because release.yml needs to be synchronized with `dist` so it just breaks every time