### PR TITLE
fix test failure when the generated UTF-8 contains the replacement character

### DIFF
--- a/crates/mds-dns-sd/proptest-regressions/util.txt
+++ b/crates/mds-dns-sd/proptest-regressions/util.txt
@@ -7,3 +7,4 @@
 cc aff0a9a8eb36d7e4bedbb69c5e5429a2f2dd157ec1415a853da40961b300f811 # shrinks to s = "\\¡"
 cc 1c2ed7855a8d2f77549509f35364545ef51217c04590631c86df2bd9e4947aad # shrinks to prefix = "", test_case = "\\07", suffix = ""
 cc c4d60947e0045192271c88d66ade0977d4917226a4b060e059da9099349ebe64 # shrinks to prefix = "", test_case = "\\\\\\", suffix = "400"
+cc 01b17690dbd7bddd63ca06f119cb1b38e16cc9b75fbc1dc82c060bd513c61f93

--- a/crates/mds-dns-sd/src/util.rs
+++ b/crates/mds-dns-sd/src/util.rs
@@ -300,7 +300,7 @@ mod proptests {
                 })
         ) {
             let octal_input: String = utf8_bytes
-                .into_iter()
+                .iter()
                 .map(|byte| format!("\\{byte:03o}"))
                 .collect();
 
@@ -308,9 +308,9 @@ mod proptests {
             let oracle = oracle_unescape(&octal_input);
 
             prop_assert_eq!(&result, &oracle);
-            // Ensure no replacement characters for valid UTF-8 input
-            prop_assert!(!result.contains('\u{FFFD}'),
-                "Valid UTF-8 should not contain replacement characters");
+            // Also check vs the round-tripped UTF-8
+            let expected_string = std::str::from_utf8(&utf8_bytes).unwrap();
+            prop_assert_eq!(result, expected_string, "The unescaped string should exactly match the original valid UTF-8 input");
         }
 
         /// Test boundary conditions and special cases


### PR DESCRIPTION
We checked that the unescaped string should never contain the
replacement character, but if the input DID contain it, then it is valid
for the unescaped string to have it. Now we simply check that it's equal
to original UTF-8.
