### PR TITLE
bump hickory-dns from 0.26.1 to 0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `ui.emojis` config option to turn off all emojis in the UI.
 
+### Dependencies
+
+- `hickory-proto`: 0.26.1 -> 0.26.3
+
 ## [0.28.0] - 2026-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,9 +1306,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+checksum = "12b92608f679a6fa515dd1d15c1ff89443026e391200a2c840c7afcba482893d"
 dependencies = [
  "data-encoding",
  "idna",

--- a/crates/mds-dns-sd/Cargo.toml
+++ b/crates/mds-dns-sd/Cargo.toml
@@ -15,7 +15,7 @@ mds-ipinfo.workspace = true
 log.workspace = true
 socket2 = { workspace = true, features = ["all"] }
 smallvec.workspace = true
-hickory-proto = { version = "0.26.1", default-features = false }
+hickory-proto = { version = "0.26.3", default-features = false }
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
Includes a lot of security/bug fixes
